### PR TITLE
SWE-agent[bot] PR to fix: Add papers to RSS feed for links

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -15,7 +15,12 @@ class LinksController < ApplicationController
   end
 
   def feed
-    @links = Link.order(created_at: :desc).limit(20)
+    # Get both links and papers, ordered by creation date
+    links = Link.order(created_at: :desc).limit(20)
+    papers = Paper.order(created_at: :desc).limit(20)
+
+    # Combine and sort by created_at, then take the first 20
+    @items = (links + papers).sort_by(&:created_at).reverse.first(20)
     respond_to do |format|
       format.atom
     end

--- a/app/views/links/feed.atom.builder
+++ b/app/views/links/feed.atom.builder
@@ -1,13 +1,25 @@
 atom_feed do |feed|
   feed.title "#{Rails.application.config.site_name} - Interesting Links Feed"
-  feed.updated(@links.first.updated_at)
+  feed.updated(@items.first&.updated_at || Time.current)
 
-  @links.each do |link|
-    feed.entry(link, id: link.uuid, url: link.url) do |entry|
-      entry.title(link.title)
-      entry.content(link.description, type: "text")
-      entry.author do |author|
-        author.name "N/A"
+  @items.each do |item|
+    if item.is_a?(Link)
+      feed.entry(item, id: item.uuid, url: item.url) do |entry|
+        entry.title(item.title)
+        entry.content(item.description, type: "text")
+        entry.author do |author|
+          author.name "N/A"
+        end
+      end
+    elsif item.is_a?(Paper)
+      # Use display_url for arXiv papers, otherwise use the paper's url
+      entry_url = item.arxiv? ? item.display_url : item.url
+      feed.entry(item, id: "paper-#{item.id}", url: entry_url) do |entry|
+        entry.title(item.title)
+        entry.content(item.description, type: "text")
+        entry.author do |author|
+          author.name "N/A"
+        end
       end
     end
   end

--- a/test/controllers/links_controller_test.rb
+++ b/test/controllers/links_controller_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "nokogiri"
 
 class LinksControllerTest < ActionDispatch::IntegrationTest
   def setup
@@ -30,6 +31,106 @@ class LinksControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_redirected_to links_path
+  end
+
+  test "feed should include both links and papers" do
+    # Stub HTTP requests for link creation
+    stub_request(:get, "http://example.com/test-link1")
+      .to_return(status: 200, body: "<html><head><title>Link 1</title><meta name='description' content='Description 1'></head></html>", headers: { "Content-Type" => "text/html" })
+    stub_request(:get, "http://example.com/test-link2")
+      .to_return(status: 200, body: "<html><head><title>Link 2</title><meta name='description' content='Description 2'></head></html>", headers: { "Content-Type" => "text/html" })
+
+    # Create some links
+    link1 = Link.create!(url: "http://example.com/test-link1")
+    link2 = Link.create!(url: "http://example.com/test-link2")
+
+    # Create some papers
+    paper1 = Paper.create!(url: "http://example.com/test-paper1.pdf", title: "Paper 1", description: "Description 1")
+    paper2 = Paper.create!(url: "http://example.com/test-paper2.pdf", title: "Paper 2", description: "Description 2")
+
+    # Make sure the papers have different created_at times
+    paper1.update(created_at: 2.days.ago)
+    paper2.update(created_at: 1.day.ago)
+
+    get links_feed_url, params: { format: "atom" }
+
+    assert_response :success
+    assert response.content_type.start_with?("application/atom+xml")
+
+    # Check that both links and papers are in the feed
+    # Note: We might have more than 4 entries if there are existing fixtures
+    assert_select "entry title", text: "Link 1"
+    assert_select "entry title", text: "Link 2"
+    assert_select "entry title", text: "Paper 1"
+    assert_select "entry title", text: "Paper 2"
+  end
+
+  test "feed should use proper URLs for arXiv papers" do
+    # Stub HTTP requests for link creation
+    stub_request(:get, "http://example.com/test-link")
+      .to_return(status: 200, body: "<html><head><title>Regular Link</title><meta name='description' content='Description'></head></html>", headers: { "Content-Type" => "text/html" })
+
+    # Create a regular link
+    link = Link.create!(url: "http://example.com/test-link")
+
+    # Create a regular paper
+    regular_paper = Paper.create!(url: "http://example.com/test-paper.pdf", title: "Regular Paper", description: "Description")
+
+    # Create an arXiv paper
+    arxiv_paper = Paper.create!(url: "https://arxiv.org/abs/1234.56789", title: "ArXiv Paper", description: "Description")
+
+    get links_feed_url, params: { format: "atom" }
+
+    assert_response :success
+
+    # Check that the regular paper uses its own URL
+    assert_select "entry link[href='#{regular_paper.url}']", count: 1
+
+    # Check that the arXiv paper uses the PDF URL
+    assert_select "entry link[href='#{arxiv_paper.display_url}']", count: 1
+  end
+
+  test "feed should be ordered by creation date" do
+    # Stub HTTP requests for link creation
+    stub_request(:get, "http://example.com/test-oldest")
+      .to_return(status: 200, body: "<html><head><title>Oldest Link</title><meta name='description' content='Description'></head></html>", headers: { "Content-Type" => "text/html" })
+    stub_request(:get, "http://example.com/test-newest")
+      .to_return(status: 200, body: "<html><head><title>Newest Link</title><meta name='description' content='Description'></head></html>", headers: { "Content-Type" => "text/html" })
+
+    # Create items at different times
+    oldest_link = Link.create!(url: "http://example.com/test-oldest")
+    oldest_link.update(created_at: 3.days.ago)
+
+    middle_paper = Paper.create!(url: "http://example.com/test-middle.pdf", title: "Middle Paper", description: "Description")
+    middle_paper.update(created_at: 2.days.ago)
+
+    newest_link = Link.create!(url: "http://example.com/test-newest")
+    newest_link.update(created_at: 1.day.ago)
+
+    get links_feed_url, params: { format: "atom" }
+
+    assert_response :success
+
+    # Parse the XML to check ordering
+    xml = Nokogiri::XML(response.body)
+    entries = xml.xpath("//xmlns:entry")
+
+    # Find our specific entries among possibly others
+    entry_titles = entries.map { |entry| entry.at_xpath(".//xmlns:title").text }
+
+    # Find positions of our test entries
+    oldest_pos = entry_titles.index("Oldest Link")
+    middle_pos = entry_titles.index("Middle Paper")
+    newest_pos = entry_titles.index("Newest Link")
+
+    # Verify that they exist
+    refute_nil oldest_pos, "Oldest Link should be in the feed"
+    refute_nil middle_pos, "Middle Paper should be in the feed"
+    refute_nil newest_pos, "Newest Link should be in the feed"
+
+    # Verify ordering: newest should come before middle, which should come before oldest
+    assert newest_pos < middle_pos, "Newest Link should come before Middle Paper"
+    assert middle_pos < oldest_pos, "Middle Paper should come before Oldest Link"
   end
 
   private


### PR DESCRIPTION
This is a PR opened by AI tool [SWE Agent](https://github.com/SWE-agent/SWE-agent/) to close [#78](https://github.com/capotej/abbey/issues/78) (Add papers to RSS feed for links).

### Details

Run with SWE-agent 1.0.1, custom Dockerfile (see below) and custom config.yaml (see below)

### Dockerfile for abbey-swe

<details>

```Dockerfile
FROM python:3.11

# Set the working directory
WORKDIR /app

# Install nodejs
RUN apt update && \
    apt install -y nodejs npm && \
    apt-get clean && \
    rm -rf /var/lib/apt/lists/*

# Install Docker CLI using the official Docker installation script
RUN curl -fsSL https://get.docker.com -o get-docker.sh && \
    sh get-docker.sh

# Copy the application code
# Do this last to take advantage of the docker layer mechanism
COPY . /app

# Install Python dependencies
RUN pip install -e '.'

# Install react dependencies ahead of time
RUN cd sweagent/frontend && npm install

# Download and compile Ruby 3.3.2
RUN wget https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.1.tar.gz \
    && tar -xzf ruby-3.4.1.tar.gz \
    && cd ruby-3.4.1 \
    && ./configure --disable-install-doc \
    && make -j$(nproc) \
    && make install \
    && cd .. \
    && rm -rf ruby-3.4.1* \
    && ldconfig

# Verify installation
RUN ruby --version

```

</details>


### System Prompt (config.yaml)

<details>

```yaml
# Formerly called: anthropic_filemap.yaml
# This template is heavily inspired by anthropic's computer use demo, but you can use
# it with any LM.
agent:
  templates:
    system_template: |-
      You are a helpful assistant that can interact with a computer to solve tasks.
    instance_template: |-
      <uploaded_files>
      {{working_dir}}
      </uploaded_files>
      I've uploaded a rails code repository in the directory {{working_dir}}. Consider the following PR description:

      <pr_description>
      {{problem_statement}}
      </pr_description>

      Can you help me implement the necessary changes to the repository so that the requirements specified in the <pr_description> are met?

      Make sure to follow AGENTS.md for rules and information about this project.

      Your thinking should be thorough and so it's fine if it's very long.
    next_step_template: |-
      OBSERVATION:
      {{observation}}
    next_step_no_output_template: |-
      Your command ran successfully and did not produce any output.
  tools:
    bundles:
      - path: tools/registry
      - path: tools/edit_anthropic
      - path: tools/review_on_submit_m
    registry_variables:
      USE_FILEMAP: 'true'
      SUBMIT_REVIEW_MESSAGES:
        - |
          Thank you for your work on this issue. Please carefully follow the steps below to help review your changes.

          1. If you made any changes to your code after running the reproduction script, please run the reproduction script again.
            If the reproduction script is failing, please revisit your changes and make sure they are correct.
            If you have already removed your reproduction script, please ignore this step.
          2. Remove your reproduction script (if you haven't done so already).
          3. If you have modified any TEST files, please revert them to the state they had before you started fixing the issue.
            You can do this with `git checkout -- /path/to/test/file.py`. Use below <diff> to find the files you need to revert.
          4. Run the submit command again to confirm.

          Here is a list of all of your changes:

          <diff>
          {{diff}}
          </diff>
    enable_bash_tool: true
    parse_function:
      type: function_calling
  history_processors:
    - type: cache_control
      last_n_messages: 2
```

</details>

Closes #78.

<details>
<summary>Thought process ('trajectory') of SWE-agent (click to expand)</summary>

**🧑‍🚒 Response (0)**: 
I'll help you implement the necessary changes to add papers to the RSS feed for links. Let me start by exploring the repository structure and understanding the current implementation.
**👀‍ Observation (0)**:
```
Here's the files and directories up to 2 levels deep in /capotej__abbey, excluding hidden items:
/capotej__abbey
/capotej__abbey/AGENTS.md
/capotej__abbey/Dockerfile
/capotej__abbey/Gemfile
/capotej__abbey/Gemfile.lock
/capotej__abbey/LICENSE
/capotej__abbey/Procfile.dev
/capotej__abbey/README.md
/capotej__abbey/Rakefile
/capotej__abbey/app
/capotej__abbey/app/assets
/capotej__abbey/app/channels
/capotej__abbey/app/controllers
/capotej__abbey/app/helpers
/capotej__abbey/app/javascript
/capotej__abbey/app/jobs
/capotej__abbey/app/mailers
/capotej__abbey/app/models
/capotej__abbey/app/services
/capotej__abbey/app/views
/capotej__abbey/bin
/capotej__abbey/bin/brakeman
/capotej__abbey/bin/bundle
/capotej__abbey/bin/dev
/capotej__abbey/bin/docker-entrypoint
/capotej__abbey/bin/importmap
/capotej__abbey/bin/jobs
/capotej__abbey/bin/kamal
/capotej__abbey/bin/rails
/capotej__abbey/bin/rake
/capotej__abbey/bin/rubocop
/capotej__abbey/bin/setup
/capotej__abbey/bin/thrust
/capotej__abbey/config.ru
/capotej__abbey/config
/capotej__abbey/config/application.rb
/capotej__abbey/config/boot.rb
/capotej__abbey/config/cable.yml
/capotej__abbey/config/cache.yml
/capotej__abbey/config/credentials.yml.enc
/capotej__abbey/config/database.yml
/capotej__abbey/config/deploy.yml
/capotej__abbey/config/environment.rb
/capotej__abbey/config/environments
/capotej__abbey/config/importmap.rb
/capotej__abbey/config/initializers
/capotej__abbey/config/locales
/capotej__abbey/config/puma.rb
/capotej__abbey/config/queue.yml
/capotej__abbey/config/recurring.yml
/capotej__abbey/config/routes.rb
/capotej__abbey/config/storage.yml
/capotej__abbey/config/tailwind.config.js
/capotej__abbey/db
/capotej__abbey/db/cable_schema.rb
/capotej__abbey/db/cache_schema.rb
/capotej__abbey/db/migrate
/capotej__abbey/db/queue_schema.rb
/capotej__abbey/db/schema.rb
/capotej__abbey/db/seeds.rb
/capotej__abbey/db/seeds
/capotej__abbey/lib
/capotej__abbey/lib/markdown_render.rb
/capotej__abbey/lib/tasks
/capotej__abbey/log
/capotej__abbey/package-lock.json
/capotej__abbey/package.json
/capotej__abbey/public
/capotej__abbey/public/400.html
/capotej__abbey/public/404.html
/capotej__abbey/public/406-unsupported-browser.html
/capotej__abbey/public/422.html
/capotej__abbey/public/500.html
/capotej__abbey/public/robots.txt
/capotej__abbey/script
/capotej__abbey/storage
/capotej__abbey/test
/capotej__abbey/test/application_system_test_case.rb
/capotej__abbey/test/controllers
/capotej__abbey/test/fixtures
/capotej__abbey/test/helpers
/capotej__abbey/test/integration
/capotej__abbey/test/jobs
/capotej__abbey/test/mailers
/capotej__abbey/test/models
/capotej__abbey/test/services
/capotej__abbey/test/system
/capotej__abbey/test/test_helper.rb
/capotej__abbey/tmp
/capotej__abbey/tmp/pids
/capotej__abbey/tmp/storage
/capotej__abbey/vendor
/capotej__abbey/vendor/javascript
```

---

**🧑‍🚒 Response (1)**: 
First, let me read the AGENTS.md file to understand the project guidelines:
**👀‍ Observation (1)**:
```
Here's the result of running `cat -n` on /capotej__abbey/AGENTS.md:
     1	# AGENTS.md
     2	
     3	## Rules
     4	
     5	<rules>
     6	**NEVER** run `bundle exec rails console`.
     7	</rules>
     8	
     9	## Commands
    10	
    11	**Test**
    12	- `rails test` - Run all tests except system tests
    13	- `rails test test/models/post_test.rb` - Run specific test file
    14	- `rails test test/models/post_test.rb:27` - Run specific test by line number
    15	- `rails test:system` - Run system tests
    16	
    17	**Lint/Format**
    18	- `bundle exec rubocop` - Run linter (uses rubocop-rails-omakase)
    19	- `bundle exec rubocop -a` - Auto-fix safe corrections
    20	- `bundle exec brakeman` - Security analysis
    21	- `bundle exec erb_lint --lint-all` - Run linter on ERB/HTML
    22	- `bundle exec erb_lint --lint-all -a` - Auto-fix safe corrections
    23	
    24	
    25	**Development**
    26	- `rails server` - Start development server
    27	- `rails console` - Start Rails console
    28	- `rails db:migrate` - Run migrations
    29	- `rails db:seed` - Seed database
    30	
    31	## Code Style
    32	
    33	**Testing**: Uses Minitest with ActiveSupport::TestCase. Test files in `test/` directory.
    34	
    35	**Linting**: Uses rubocop-rails-omakase (Omakase Ruby styling for Rails).
    36	
    37	**Models**: Include concerns from `concerns/` directory. Use `validates_presence_of`, scopes, and lifecycle callbacks.
    38	
    39	**Controllers**: Inherit from ApplicationController. Use `allow_unauthenticated_access` for public actions. Find records with `find_by_slug!` for posts.
    40	
    41	**Naming**: Snake_case for methods/variables, CamelCase for classes. Use descriptive method names like `rendered_body` and `post_scope`.
    42	
    43	**Structure**: Standard Rails MVC. Models in `app/models/`, controllers in `app/controllers/`, tests mirror app structure in `test/`.
    44	
    45	## HTML/CSS Styling
    46	
    47	**Tailwind**: When writing HTML, always use Tailwind CSS. Make sure to support both dark/light mode where appropriate. 
    48
```

---

**🧑‍🚒 Response (2)**: 
Now let me examine the current implementation of the links feed and understand how papers are structured. First, let's look at the routes:
**👀‍ Observation (2)**:
```
Here's the result of running `cat -n` on /capotej__abbey/config/routes.rb:
     1	Rails.application.routes.draw do
     2	  get "up" => "rails/health#show", as: :rails_health_check
     3	
     4	  # logins
     5	  resource :session
     6	
     7	  # posts
     8	  resources :posts, controller: "blog", except: :show
     9	
    10	  get "/blog/:year/:month/:day/:id/", to: "blog#show", as: "dated_post"
    11	  get "/blog/feed", to: "blog#feed", defaults: { format: "atom" }
    12	  get "/post/*slug", to: "blog#redirect"
    13	
    14	  # tags
    15	  get "/t/:id", to: "blog#index_by_tag", as: "tag"
    16	  get "/t/:id/feed", to: "blog#feed_by_tag", defaults: { format: "atom" }, as: "tag_feed"
    17	
    18	  # pages
    19	  resources :pages, except: :index, path: "p"
    20	
    21	  # feed reader
    22	  resources :feeds, except: :show
    23	  resources :feed_posts, only: :index do
    24	    post "/promote", to: "feed_posts#promote", as: "promote"
    25	  end
    26	
    27	
    28	  # links
    29	  resources :links, except: :show
    30	  get "/links/feed", to: "links#feed", defaults: { format: "atom" }
    31	
    32	  # papers
    33	  resources :papers, except: [ :show ]
    34	
    35	  # handle old pages from capotej.com
    36	  get "/about", to: redirect("/p/about")
    37	  get "/projects", to: redirect("/p/projects")
    38	  get "/presentations", to: redirect("/p/presentations")
    39	  get "/render-image-links-directly-inside-adium", to: "blog#redirect"
    40	  get "/finagle-with-scala-bootstrapper", to: "blog#redirect"
    41	  get "/alfred-extension-for-creating-wunderlist-task", to: "blog#redirect"
    42	
    43	  # home page
    44	  root "blog#index"
    45	end
    46
```

---

**🧑‍🚒 Response (3)**: 
Now let's look at the links controller to understand the current feed implementation:
**👀‍ Observation (3)**:
```
Here's the result of running `cat -n` on /capotej__abbey/app/controllers/links_controller.rb:
     1	class LinksController < ApplicationController
     2	  include ActiveStorage::SetCurrent
     3	  allow_unauthenticated_access only: %i[ index feed ]
     4	
     5	  def edit
     6	    @link = Link.find(params[:id])
     7	  end
     8	
     9	  def new
    10	    @link = Link.new
    11	  end
    12	
    13	  def index
    14	    @links = Link.order(created_at: :desc).page(params[:page])
    15	  end
    16	
    17	  def feed
    18	    @links = Link.order(created_at: :desc).limit(20)
    19	    respond_to do |format|
    20	      format.atom
    21	    end
    22	  end
    23	
    24	  def create
    25	    url = link_params[:url]
    26	
    27	    # Check if the URL points to a PDF and create a paper if it does
    28	    paper = PdfPaperCreator.create_from_url(url)
    29	    if paper
    30	      redirect_to papers_path
    31	    else
    32	      create_link
    33	    end
    34	  end
    35	
    36	  def update
    37	    @link = Link.find(params[:id])
    38	    if @link.update(link_params)
    39	      redirect_to links_path
    40	    else
    41	      render :edit, status: :unprocessable_content
    42	    end
    43	  end
    44	
    45	  def destroy
    46	    @link = Link.find(params[:id])
    47	    @link.destroy
    48	    redirect_to links_path
    49	  end
    50	
    51	  private
    52	    def link_params
    53	      params.expect(link: [ :title, :description, :url ])
    54	    end
    55	
    56	    def create_link
    57	      @link = Link.new(link_params)
    58	      if @link.save
    59	        redirect_to links_path
    60	      else
    61	        render :new, status: :unprocessable_content
    62	      end
    63	    end
    64	end
    65
```

---

**🧑‍🚒 Response (4)**: 
Now let's look at the current feed view:
**👀‍ Observation (4)**:
```

```

---

**🧑‍🚒 Response (5)**: 
Let me check the current feed view implementation:
**👀‍ Observation (5)**:
```
Here's the result of running `cat -n` on /capotej__abbey/app/views/links/feed.atom.builder:
     1	atom_feed do |feed|
     2	  feed.title "#{Rails.application.config.site_name} - Interesting Links Feed"
     3	  feed.updated(@links.first.updated_at)
     4	
     5	  @links.each do |link|
     6	    feed.entry(link, id: link.uuid, url: link.url) do |entry|
     7	      entry.title(link.title)
     8	      entry.content(link.description, type: "text")
     9	      entry.author do |author|
    10	        author.name "N/A"
    11	      end
    12	    end
    13	  end
    14	end
    15
```

---

**🧑‍🚒 Response (6)**: 
Now let's examine the Paper model to understand its structure:
**👀‍ Observation (6)**:
```
Here's the files and directories up to 2 levels deep in /capotej__abbey/app/models, excluding hidden items:
/capotej__abbey/app/models
/capotej__abbey/app/models/application_record.rb
/capotej__abbey/app/models/concerns
/capotej__abbey/app/models/concerns/rendering.rb
/capotej__abbey/app/models/current.rb
/capotej__abbey/app/models/feed.rb
/capotej__abbey/app/models/feed_post.rb
/capotej__abbey/app/models/link.rb
/capotej__abbey/app/models/page.rb
/capotej__abbey/app/models/paper.rb
/capotej__abbey/app/models/post.rb
/capotej__abbey/app/models/session.rb
/capotej__abbey/app/models/tag.rb
/capotej__abbey/app/models/tagging.rb
/capotej__abbey/app/models/user.rb
```

---

**🧑‍🚒 Response (7)**: 

**👀‍ Observation (7)**:
```
Here's the result of running `cat -n` on /capotej__abbey/app/models/paper.rb:
     1	require "net/http"
     2	require "uri"
     3	
     4	class Paper < ApplicationRecord
     5	  validates_presence_of :url
     6	  validates :url, uniqueness: true
     7	
     8	  has_one_attached :pdf
     9	
    10	  before_create :set_title_and_desc
    11	
    12	  paginates_per 15
    13	
    14	  def arxiv?
    15	    url&.include?("arxiv.org")
    16	  end
    17	
    18	  def arxiv_pdf_url
    19	    return nil unless arxiv?
    20	
    21	    if url.include?("arxiv.org/abs/")
    22	      url.gsub("arxiv.org/abs/", "arxiv.org/pdf/")
    23	    elsif url.include?("arxiv.org/pdf/")
    24	      url
    25	    else
    26	      nil
    27	    end
    28	  end
    29	
    30	  def display_url
    31	    arxiv? ? arxiv_pdf_url : nil
    32	  end
    33	
    34	  private
    35	
    36	  def set_title_and_desc
    37	    # Try to get title and description from the PDF metadata or URL
    38	    self.title ||= extract_title_from_url
    39	    self.description ||= "PDF document from #{url}"
    40	  end
    41	
    42	  def extract_title_from_url
    43	    # Extract filename from URL if possible
    44	    uri = URI.parse(url)
    45	    filename = File.basename(uri.path, ".*")
    46	
    47	    # If filename is meaningful, use it as title
    48	    if filename.present? && filename != "index" && filename.length > 3
    49	      filename.gsub(/[-_]/, " ").titleize
    50	    else
    51	      "Untitled Paper"
    52	    end
    53	  end
    54	end
    55
```

---

**🧑‍🚒 Response (8)**: 
Let's also check the Link model for comparison:
**👀‍ Observation (8)**:
```
Here's the result of running `cat -n` on /capotej__abbey/app/models/link.rb:
     1	require "metainspector"
     2	
     3	class Link < ApplicationRecord
     4	  validates_presence_of :url
     5	
     6	  before_create :set_title_and_desc
     7	
     8	  paginates_per 15
     9	
    10	  def uuid
    11	    Digest::SHA2.hexdigest self.url
    12	  end
    13	
    14	  private
    15	  def set_title_and_desc
    16	    page = MetaInspector.new(self.url)
    17	    self.title = page.best_title
    18	    self.description = page.best_description
    19	  end
    20	end
    21
```

---

**🧑‍🚒 Response (9)**: 
Now let's check the database schema to understand the structure of both models:
**👀‍ Observation (9)**:
```
Here's the result of running `cat -n` on /capotej__abbey/db/schema.rb:
     1	# This file is auto-generated from the current state of the database. Instead
     2	# of editing this file, please use the migrations feature of Active Record to
     3	# incrementally modify your database, and then regenerate this schema definition.
     4	#
     5	# This file is the source Rails uses to define your schema when running `bin/rails
     6	# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
     7	# be faster and is potentially less error prone than running all of your
     8	# migrations from scratch. Old migrations may fail to apply correctly if those
     9	# migrations use external dependencies or application code.
    10	#
    11	# It's strongly recommended that you check this file into your version control system.
    12	
    13	ActiveRecord::Schema[8.0].define(version: 2025_08_30_213252) do
    14	  create_table "active_storage_attachments", force: :cascade do |t|
    15	    t.string "name", null: false
    16	    t.string "record_type", null: false
    17	    t.bigint "record_id", null: false
    18	    t.bigint "blob_id", null: false
    19	    t.datetime "created_at", null: false
    20	    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
    21	    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
    22	  end
    23	
    24	  create_table "active_storage_blobs", force: :cascade do |t|
    25	    t.string "key", null: false
    26	    t.string "filename", null: false
    27	    t.string "content_type"
    28	    t.text "metadata"
    29	    t.string "service_name", null: false
    30	    t.bigint "byte_size", null: false
    31	    t.string "checksum"
    32	    t.datetime "created_at", null: false
    33	    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
    34	  end
    35	
    36	  create_table "active_storage_variant_records", force: :cascade do |t|
    37	    t.bigint "blob_id", null: false
    38	    t.string "variation_digest", null: false
    39	    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
    40	  end
    41	
    42	  create_table "feed_posts", force: :cascade do |t|
    43	    t.string "guid"
    44	    t.string "summary"
    45	    t.string "url"
    46	    t.string "title"
    47	    t.integer "feed_id"
    48	    t.datetime "created_at", null: false
    49	    t.datetime "updated_at", null: false
    50	    t.datetime "published_at"
    51	    t.boolean "promoted"
    52	    t.index ["guid"], name: "index_feed_posts_on_guid", unique: true
    53	  end
    54	
    55	  create_table "feeds", force: :cascade do |t|
    56	    t.string "name", null: false
    57	    t.string "url", null: false
    58	    t.datetime "created_at", null: false
    59	    t.datetime "updated_at", null: false
    60	    t.index ["name", "url"], name: "index_feeds_on_name_and_url", unique: true
    61	  end
    62	
    63	  create_table "links", force: :cascade do |t|
    64	    t.string "url"
    65	    t.string "title"
    66	    t.string "description"
    67	    t.datetime "created_at", null: false
    68	    t.datetime "updated_at", null: false
    69	    t.index ["url"], name: "index_links_on_url", unique: true
    70	  end
    71	
    72	  create_table "pages", force: :cascade do |t|
    73	    t.string "title"
    74	    t.string "slug"
    75	    t.datetime "created_at", null: false
    76	    t.datetime "updated_at", null: false
    77	    t.text "markdown_body"
    78	    t.index ["slug"], name: "index_pages_on_slug", unique: true
    79	  end
    80	
    81	  create_table "papers", force: :cascade do |t|
    82	    t.string "title"
    83	    t.text "description"
    84	    t.string "url"
    85	    t.datetime "created_at", null: false
    86	    t.datetime "updated_at", null: false
    87	    t.index ["url"], name: "index_papers_on_url", unique: true
    88	  end
    89	
    90	  create_table "posts", force: :cascade do |t|
    91	    t.boolean "draft"
    92	    t.string "title"
    93	    t.datetime "created_at", null: false
    94	    t.datetime "updated_at", null: false
    95	    t.string "slug"
    96	    t.text "markdown_excerpt"
    97	    t.text "markdown_body"
    98	    t.string "redirect_from"
    99	    t.index ["draft"], name: "index_posts_on_draft"
   100	    t.index ["redirect_from"], name: "index_posts_on_redirect_from", unique: true
   101	    t.index ["slug"], name: "index_posts_on_slug", unique: true
   102	  end
   103	
   104	  create_table "sessions", force: :cascade do |t|
   105	    t.integer "user_id", null: false
   106	    t.string "ip_address"
   107	    t.string "user_agent"
   108	    t.datetime "created_at", null: false
   109	    t.datetime "updated_at", null: false
   110	    t.index ["user_id"], name: "index_sessions_on_user_id"
   111	  end
   112	
   113	  create_table "taggings", force: :cascade do |t|
   114	    t.integer "post_id"
   115	    t.integer "tag_id"
   116	    t.datetime "created_at", null: false
   117	    t.datetime "updated_at", null: false
   118	    t.index ["post_id", "tag_id"], name: "index_taggings_on_post_id_and_tag_id", unique: true
   119	  end
   120	
   121	  create_table "tags", force: :cascade do |t|
   122	    t.string "name"
   123	    t.datetime "created_at", null: false
   124	    t.datetime "updated_at", null: false
   125	    t.index ["name"], name: "index_tags_on_name", unique: true
   126	  end
   127	
   128	  create_table "users", force: :cascade do |t|
   129	    t.string "email_address", null: false
   130	    t.string "password_digest", null: false
   131	    t.datetime "created_at", null: false
   132	    t.datetime "updated_at", null: false
   133	    t.index ["email_address"], name: "index_users_on_email_address", unique: true
   134	  end
   135	
   136	  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   137	  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   138	  add_foreign_key "sessions", "users"
   139	end
   140
```

---

**🧑‍🚒 Response (10)**: 
Now let's check if there are any existing tests for the links feed to understand the testing approach:
**👀‍ Observation (10)**:
```
Here's the files and directories up to 2 levels deep in /capotej__abbey/test, excluding hidden items:
/capotej__abbey/test
/capotej__abbey/test/application_system_test_case.rb
/capotej__abbey/test/controllers
/capotej__abbey/test/controllers/blog_controller_test.rb
/capotej__abbey/test/controllers/feed_posts_controller_test.rb
/capotej__abbey/test/controllers/links_controller_test.rb
/capotej__abbey/test/controllers/papers_controller_test.rb
/capotej__abbey/test/fixtures
/capotej__abbey/test/fixtures/feed_posts.yml
/capotej__abbey/test/fixtures/feeds.yml
/capotej__abbey/test/fixtures/files
/capotej__abbey/test/fixtures/links.yml
/capotej__abbey/test/fixtures/pages.yml
/capotej__abbey/test/fixtures/posts.yml
/capotej__abbey/test/fixtures/taggings.yml
/capotej__abbey/test/fixtures/tags.yml
/capotej__abbey/test/fixtures/users.yml
/capotej__abbey/test/helpers
/capotej__abbey/test/helpers/papers_helper_test.rb
/capotej__abbey/test/integration
/capotej__abbey/test/jobs
/capotej__abbey/test/jobs/fetch_feed_job_test.rb
/capotej__abbey/test/jobs/fetch_feeds_job_test.rb
/capotej__abbey/test/jobs/prune_old_feed_posts_job_test.rb
/capotej__abbey/test/mailers
/capotej__abbey/test/mailers/previews
/capotej__abbey/test/models
/capotej__abbey/test/models/feed_post_test.rb
/capotej__abbey/test/models/feed_test.rb
/capotej__abbey/test/models/link_test.rb
/capotej__abbey/test/models/page_test.rb
/capotej__abbey/test/models/paper_test.rb
/capotej__abbey/test/models/post_test.rb
/capotej__abbey/test/models/tag_test.rb
/capotej__abbey/test/models/tagging_test.rb
/capotej__abbey/test/models/user_test.rb
/capotej__abbey/test/services
/capotej__abbey/test/services/pdf_paper_creator_test.rb
/capotej__abbey/test/system
/capotej__abbey/test/test_helper.rb
```

---

**🧑‍🚒 Response (11)**: 
Let's look at the existing links controller tests:
**👀‍ Observation (11)**:
```
Here's the result of running `cat -n` on /capotej__abbey/test/controllers/links_controller_test.rb:
     1	require "test_helper"
     2	
     3	class LinksControllerTest < ActionDispatch::IntegrationTest
     4	  def setup
     5	    @user = users(:one)
     6	    sign_in @user
     7	  end
     8	
     9	  test "should create paper when PDF URL is provided" do
    10	    stub_request(:head, "http://example.com/paper.pdf")
    11	      .to_return(status: 200, headers: { "Content-Type" => "application/pdf" })
    12	    stub_request(:get, "http://example.com/paper.pdf")
    13	      .to_return(status: 200, body: "PDF content", headers: { "Content-Type" => "application/pdf" })
    14	
    15	    assert_difference("Paper.count", 1) do
    16	      post links_url, params: { link: { url: "http://example.com/paper.pdf", title: "Test PDF" } }
    17	    end
    18	
    19	    assert_redirected_to papers_path
    20	  end
    21	
    22	  test "should create link when non-PDF URL is provided" do
    23	    stub_request(:head, "http://example.com/page.html")
    24	      .to_return(status: 200, headers: { "Content-Type" => "text/html" })
    25	    stub_request(:get, "http://example.com/page.html")
    26	      .to_return(status: 200, body: "<html><head><title>Test Page</title><meta name='description' content='Test description'></head></html>", headers: { "Content-Type" => "text/html" })
    27	
    28	    assert_difference("Link.count", 1) do
    29	      post links_url, params: { link: { url: "http://example.com/page.html", title: "Test Page" } }
    30	    end
    31	
    32	    assert_redirected_to links_path
    33	  end
    34	
    35	  private
    36	
    37	  def sign_in(user)
    38	    post session_url, params: { email_address: user.email_address, password: "password" }
    39	  end
    40	end
    41
```

---

**🧑‍🚒 Response (12)**: 
Let's also check if there are any existing tests for the feed functionality:
**👀‍ Observation (12)**:
```

```

---

**🧑‍🚒 Response (13)**: 
Let me check if there are any existing tests specifically for the links feed:
**👀‍ Observation (13)**:
```

```

---

**🧑‍🚒 Response (14)**: 
It seems there are no existing tests for the links feed. Let me check the fixtures to understand the test data structure:
**👀‍ Observation (14)**:
```
Here's the result of running `cat -n` on /capotej__abbey/test/fixtures/links.yml:
     1	# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
     2	
     3	one:
     4	  url: http://example.com/link1
     5	
     6	two:
     7	  url: http://example.com/link2
     8
```

---

**🧑‍🚒 Response (15)**: 

**👀‍ Observation (15)**:
```
The path /capotej__abbey/test/fixtures/papers.yml does not exist. Please provide a valid path.
```

---

**🧑‍🚒 Response (16)**: 
Let me check if there are any papers fixtures:
**👀‍ Observation (16)**:
```

```

---

**🧑‍🚒 Response (17)**: 
Let me check the paper model tests to understand how papers are tested:
**👀‍ Observation (17)**:
```
Here's the result of running `cat -n` on /capotej__abbey/test/models/paper_test.rb:
     1	require "test_helper"
     2	
     3	class PaperTest < ActiveSupport::TestCase
     4	  test "paper should be valid with url" do
     5	    paper = Paper.new(url: "http://example.com/paper.pdf")
     6	    assert paper.valid?
     7	  end
     8	
     9	  test "paper should not be valid without url" do
    10	    paper = Paper.new
    11	    assert_not paper.valid?
    12	  end
    13	
    14	  test "paper should have unique url" do
    15	    paper1 = Paper.create!(url: "http://example.com/paper.pdf")
    16	    paper2 = Paper.new(url: "http://example.com/paper.pdf")
    17	    assert_not paper2.valid?
    18	  end
    19	end
    20
```

---

**🧑‍🚒 Response (18)**: 
Now let me understand how the feed should work. Based on the requirements, I need to:

1. Modify the links controller's feed action to include both Links and Papers
2. Update the feed view to handle both types of entries
3. Write tests to ensure the feed includes both Links and Papers
4. Ensure proper URLs are used for arXiv and regular papers

Let me first check if there are any existing examples of combining different model types in feeds by looking at the blog controller:
**👀‍ Observation (18)**:
```
Here's the result of running `cat -n` on /capotej__abbey/app/controllers/blog_controller.rb:
     1	class BlogController < ApplicationController
     2	  include ActiveStorage::SetCurrent
     3	
     4	  allow_unauthenticated_access only: %i[ index show feed index_by_tag redirect feed_by_tag ]
     5	
     6	  def show
     7	    @post = post_scope.find_by_slug!(params[:id])
     8	  end
     9	
    10	  def edit
    11	    @post = Post.find_by_slug(params[:id])
    12	  end
    13	
    14	  def new
    15	    @post = Post.new
    16	  end
    17	
    18	  def index
    19	    @posts = post_scope.order(created_at: :desc).page(params[:page])
    20	  end
    21	
    22	  def redirect
    23	    # handle /post/, post/, /post
    24	    uri = Addressable::URI.parse(request.original_url)
    25	    sanitized_uri = uri.path.squeeze("/").delete_suffix("/")
    26	    redirect_from_post = Post.find_by(redirect_from: sanitized_uri)
    27	
    28	    if redirect_from_post
    29	      redirect_to dated_post_path(year: redirect_from_post.year, month: redirect_from_post.month, day: redirect_from_post.day, id: redirect_from_post.slug), status: :moved_permanently
    30	    else
    31	      raise ActiveRecord::RecordNotFound
    32	    end
    33	  end
    34	
    35	  def feed
    36	    @posts = post_scope.order(created_at: :desc).limit(20)
    37	    respond_to do |format|
    38	      format.atom
    39	    end
    40	  end
    41	
    42	  def index_by_tag
    43	    @tag = Tag.find_by_name!(params[:id])
    44	    @posts = post_scope.order(created_at: :desc).joins(:tags).where(tags: @tag).page(params[:page])
    45	  end
    46	
    47	  def feed_by_tag
    48	    @tag = Tag.find_by_name!(params[:id])
    49	    @posts = post_scope.order(created_at: :desc).joins(:tags).where(tags: @tag).limit(20)
    50	    respond_to do |format|
    51	      format.atom
    52	    end
    53	  end
    54	
    55	  def create
    56	    @post = Post.new(post_params)
    57	    if @post.save
    58	      redirect_to dated_post_path(year: @post.year, month: @post.month, day: @post.day, id: @post.slug)
    59	    else
    60	      render :new, status: :unprocessable_content
    61	    end
    62	  end
    63	
    64	  def update
    65	    @post = Post.find_by_slug(params[:id])
    66	    @post.markdown_body_attachments.purge
    67	    if @post.update(post_params)
    68	      redirect_to dated_post_path(year: @post.year, month: @post.month, day: @post.day, id: @post.slug)
    69	    else
    70	      render :edit, status: :unprocessable_content
    71	    end
    72	  end
    73	
    74	  def destroy
    75	    post = Post.find_by_slug(params[:id])
    76	    post.destroy
    77	    redirect_to posts_path
    78	  end
    79	
    80	  private
    81	    def post_params
    82	      params.expect(post: [ :title, :markdown_body, :slug, :post_tags, :markdown_excerpt, :draft ])
    83	    end
    84	
    85	    def post_scope
    86	      if authenticated?
    87	        Post
    88	      else
    89	        Post.published
    90	      end
    91	    end
    92	end
    93
```

---

**🧑‍🚒 Response (19)**: 
Let me look at the blog feed view to understand the structure:
**👀‍ Observation (19)**:
```
Here's the result of running `cat -n` on /capotej__abbey/app/views/blog/feed.atom.builder:
     1	atom_feed do |feed|
     2	  feed.title "#{Rails.application.config.site_name} - Feed"
     3	  feed.updated(@posts.first.updated_at)
     4	
     5	  @posts.each do |post|
     6	    feed.entry(post, id: post.uuid, url: dated_post_url(year: post.year, day: post.day, month: post.month, id: post)) do |entry|
     7	      entry.title(post.title)
     8	      entry.content(post.rendered_body, type: "html")
     9	      entry.author do |author|
    10	        author.name "Julio Capote"
    11	      end
    12	    end
    13	  end
    14	end
    15
```

---

**🧑‍🚒 Response (20)**: 
Now I have a good understanding of the current implementation. Let me implement the required changes:

1. First, I'll modify the links controller to include papers in the feed
2. Then update the feed view to handle both links and papers
3. Finally, write tests to ensure the functionality works correctly

Let's start by modifying the links controller:
**👀‍ Observation (20)**:
```
The file /capotej__abbey/app/controllers/links_controller.rb has been edited. Here's the result of running `cat -n` on a snippet of /capotej__abbey/app/controllers/links_controller.rb:
    12	
    13	  def index
    14	    @links = Link.order(created_at: :desc).page(params[:page])
    15	  end
    16	
    17	  def feed
    18	    # Get both links and papers, ordered by creation date
    19	    @items = (Link.all + Paper.all).sort_by(&:created_at).reverse.first(20)
    20	    respond_to do |format|
    21	      format.atom
    22	    end
    23	  end
    24	
    25	  def create
    26	    url = link_params[:url]
Review the changes and make sure they are as expected. Edit the file again if necessary.
```

---

**🧑‍🚒 Response (21)**: 
Now I need to update the feed view to handle both links and papers. Let me modify the feed.atom.builder file:
**👀‍ Observation (21)**:
```
The file /capotej__abbey/app/views/links/feed.atom.builder has been edited. Here's the result of running `cat -n` on a snippet of /capotej__abbey/app/views/links/feed.atom.builder:
     1	atom_feed do |feed|
     2	  feed.title "#{Rails.application.config.site_name} - Interesting Links Feed"
     3	  feed.updated(@items.first.updated_at)
     4	
     5	  @items.each do |item|
     6	    if item.is_a?(Link)
     7	      feed.entry(item, id: item.uuid, url: item.url) do |entry|
     8	        entry.title(item.title)
     9	        entry.content(item.description, type: "text")
    10	        entry.author do |author|
    11	          author.name "N/A"
    12	        end
    13	      end
    14	    elsif item.is_a?(Paper)
    15	      # Use display_url for arXiv papers, otherwise use the paper's url
    16	      entry_url = item.arxiv? ? item.display_url : item.url
    17	      feed.entry(item, id: "paper-#{item.id}", url: entry_url) do |entry|
    18	        entry.title(item.title)
    19	        entry.content(item.description, type: "text")
    20	        entry.author do |author|
    21	          author.name "N/A"
    22	        end
    23	      end
    24	    end
    25	  end
    26	end
Review the changes and make sure they are as expected. Edit the file again if necessary.
```

---

**🧑‍🚒 Response (22)**: 
I need to handle the case where there might be no items. Let me add a safety check:
**👀‍ Observation (22)**:
```
The file /capotej__abbey/app/views/links/feed.atom.builder has been edited. Here's the result of running `cat -n` on a snippet of /capotej__abbey/app/views/links/feed.atom.builder:
     1	atom_feed do |feed|
     2	  feed.title "#{Rails.application.config.site_name} - Interesting Links Feed"
     3	  feed.updated(@items.first&.updated_at || Time.current)
     4	
     5	  @items.each do |item|
     6	    if item.is_a?(Link)
     7	      feed.entry(item, id: item.uuid, url: item.url) do |entry|
     8	        entry.title(item.title)
     9	        entry.content(item.description, type: "text")
    10	        entry.author do |author|
    11	          author.name "N/A"
    12	        end
    13	      end
    14	    elsif item.is_a?(Paper)
    15	      # Use display_url for arXiv papers, otherwise use the paper's url
    16	      entry_url = item.arxiv? ? item.display_url : item.url
    17	      feed.entry(item, id: "paper-#{item.id}", url: entry_url) do |entry|
    18	        entry.title(item.title)
    19	        entry.content(item.description, type: "text")
    20	        entry.author do |author|
    21	          author.name "N/A"
    22	        end
    23	      end
    24	    end
    25	  end
    26	end
Review the changes and make sure they are as expected. Edit the file again if necessary.
```

---

**🧑‍🚒 Response (23)**: 
Now I need to create a test for the links feed that includes both links and papers. Let me create a new test file or add to the existing one:
**👀‍ Observation (23)**:
```
usage: str_replace_editor [-h] [--file_text FILE_TEXT]
                          [--view_range VIEW_RANGE VIEW_RANGE]
                          [--old_str OLD_STR] [--new_str NEW_STR]
                          [--insert_line INSERT_LINE]
                          command path
str_replace_editor: error: argument --view_range: expected 2 arguments
```

---

**🧑‍🚒 Response (24)**: 

**👀‍ Observation (24)**:
```
usage: str_replace_editor [-h] [--file_text FILE_TEXT]
                          [--view_range VIEW_RANGE VIEW_RANGE]
                          [--old_str OLD_STR] [--new_str NEW_STR]
                          [--insert_line INSERT_LINE]
                          command path
str_replace_editor: error: argument --view_range: expected 2 arguments
```

---

**🧑‍🚒 Response (25)**: 

**👀‍ Observation (25)**:
```
Here's the result of running `cat -n` on /capotej__abbey/test/controllers/links_controller_test.rb:
    35	  private
    36	
    37	  def sign_in(user)
    38	    post session_url, params: { email_address: user.email_address, password: "password" }
    39	  end
    40	end
    41
```

---

**🧑‍🚒 Response (26)**: 
Let me add tests for the feed functionality. I'll add them to the existing links controller test file:
**👀‍ Observation (26)**:
```

```

---

**🧑‍🚒 Response (27)**: 

**👀‍ Observation (27)**:
```
The file /capotej__abbey/test/controllers/links_controller_test.rb has been edited. Here's the result of running `cat -n` on a snippet of /capotej__abbey/test/controllers/links_controller_test.rb:
    30	    end
    31	
    32	    assert_redirected_to links_path
    33	  end
    34	
    35	  test "feed should include both links and papers" do
    36	    # Create some links
    37	    link1 = Link.create!(url: "http://example.com/link1", title: "Link 1", description: "Description 1")
    38	    link2 = Link.create!(url: "http://example.com/link2", title: "Link 2", description: "Description 2")
    39	    
    40	    # Create some papers
    41	    paper1 = Paper.create!(url: "http://example.com/paper1.pdf", title: "Paper 1", description: "Description 1")
    42	    paper2 = Paper.create!(url: "http://example.com/paper2.pdf", title: "Paper 2", description: "Description 2")
    43	    
    44	    # Make sure the papers have different created_at times
    45	    paper1.update(created_at: 2.days.ago)
    46	    paper2.update(created_at: 1.day.ago)
    47	    
    48	    get links_feed_url, params: { format: "atom" }
    49	    
    50	    assert_response :success
    51	    assert_equal "application/atom+xml", response.content_type
    52	    
    53	    # Check that both links and papers are in the feed
    54	    assert_select "entry", count: 4
    55	    assert_select "entry title", text: "Link 1"
    56	    assert_select "entry title", text: "Link 2"
    57	    assert_select "entry title", text: "Paper 1"
    58	    assert_select "entry title", text: "Paper 2"
    59	  end
    60	
    61	  test "feed should use proper URLs for arXiv papers" do
    62	    # Create a regular link
    63	    link = Link.create!(url: "http://example.com/link", title: "Regular Link", description: "Description")
    64	    
    65	    # Create a regular paper
    66	    regular_paper = Paper.create!(url: "http://example.com/paper.pdf", title: "Regular Paper", description: "Description")
    67	    
    68	    # Create an arXiv paper
    69	    arxiv_paper = Paper.create!(url: "https://arxiv.org/abs/1234.56789", title: "ArXiv Paper", description: "Description")
    70	    
    71	    get links_feed_url, params: { format: "atom" }
    72	    
    73	    assert_response :success
    74	    
    75	    # Check that the regular paper uses its own URL
    76	    assert_select "entry id:contains('paper-#{regular_paper.id}') + link[href='#{regular_paper.url}']", count: 1
    77	    
    78	    # Check that the arXiv paper uses the PDF URL
    79	    assert_select "entry id:contains('paper-#{arxiv_paper.id}') + link[href='#{arxiv_paper.display_url}']", count: 1
    80	  end
    81	
    82	  test "feed should be ordered by creation date" do
    83	    # Create items at different times
    84	    oldest_link = Link.create!(url: "http://example.com/oldest", title: "Oldest Link", description: "Description")
    85	    oldest_link.update(created_at: 3.days.ago)
    86	    
    87	    middle_paper = Paper.create!(url: "http://example.com/middle.pdf", title: "Middle Paper", description: "Description")
    88	    middle_paper.update(created_at: 2.days.ago)
    89	    
    90	    newest_link = Link.create!(url: "http://example.com/newest", title: "Newest Link", description: "Description")
    91	    newest_link.update(created_at: 1.day.ago)
    92	    
    93	    get links_feed_url, params: { format: "atom" }
    94	    
    95	    assert_response :success
    96	    
    97	    # Parse the XML to check ordering
    98	    xml = Nokogiri::XML(response.body)
    99	    entries = xml.xpath("//xmlns:entry")
   100	    
   101	    # Should have 3 entries
   102	    assert_equal 3, entries.length
   103	    
   104	    # First entry should be the newest (newest_link)
   105	    first_title = entries[0].at_xpath(".//xmlns:title").text
   106	    assert_equal "Newest Link", first_title
   107	    
   108	    # Second entry should be the middle one (middle_paper)
   109	    second_title = entries[1].at_xpath(".//xmlns:title").text
   110	    assert_equal "Middle Paper", second_title
   111	    
   112	    # Third entry should be the oldest (oldest_link)
   113	    third_title = entries[2].at_xpath(".//xmlns:title").text
   114	    assert_equal "Oldest Link", third_title
   115	  end
   116	
   117	  private
   118	
   119	  def sign_in(user)
   120	    post session_url, params: { email_address: user.email_address, password: "password" }
   121	  end
   122	end
Review the changes and make sure they are as expected. Edit the file again if necessary.
```

---

**🧑‍🚒 Response (28)**: 
I need to add the Nokogiri require statement at the top of the test file:
**👀‍ Observation (28)**:
```
The file /capotej__abbey/test/controllers/links_controller_test.rb has been edited. Here's the result of running `cat -n` on a snippet of /capotej__abbey/test/controllers/links_controller_test.rb:
     1	require "test_helper"
     2	require "nokogiri"
     3	
     4	class LinksControllerTest < ActionDispatch::IntegrationTest
     5	  def setup
Review the changes and make sure they are as expected. Edit the file again if necessary.
```

---

**🧑‍🚒 Response (29)**: 
There's an issue with my implementation. The way I'm combining the links and papers in the controller is inefficient. Let me optimize this by using a more database-efficient approach:
**👀‍ Observation (29)**:
```
The file /capotej__abbey/app/controllers/links_controller.rb has been edited. Here's the result of running `cat -n` on a snippet of /capotej__abbey/app/controllers/links_controller.rb:
    12	
    13	  def index
    14	    @links = Link.order(created_at: :desc).page(params[:page])
    15	  end
    16	
    17	  def feed
    18	    # Get both links and papers, ordered by creation date
    19	    links = Link.order(created_at: :desc).limit(20)
    20	    papers = Paper.order(created_at: :desc).limit(20)
    21	    
    22	    # Combine and sort by created_at, then take the first 20
    23	    @items = (links + papers).sort_by(&:created_at).reverse.first(20)
    24	    respond_to do |format|
    25	      format.atom
    26	    end
    27	  end
    28	
    29	  def create
    30	    url = link_params[:url]
Review the changes and make sure they are as expected. Edit the file again if necessary.
```

---

**🧑‍🚒 Response (30)**: 
Now let's run the tests to see if our implementation works correctly:
**👀‍ Observation (30)**:
```
bash: rails: command not found
```

---

**🧑‍🚒 Response (31)**: 
Let me check if there's a specific way to run tests in this environment:
**👀‍ Observation (31)**:
```
Could not find rails-8.0.2.1, propshaft-1.2.1, sqlite3-2.7.3-aarch64-linux-gnu, sqlite3-2.7.3, puma-7.0.1, importmap-rails-2.2.2, turbo-rails-2.0.16, stimulus-rails-1.3.4, jbuilder-2.14.1, bcrypt-3.1.20, solid_cache-1.0.7, solid_queue-1.2.1, solid_cable-3.0.12, bootsnap-1.18.6, kamal-2.7.0, thruster-0.1.15-aarch64-linux, thruster-0.1.15, image_processing-1.14.0, debug-1.11.0, brakeman-7.1.0, rubocop-rails-omakase-1.1.0, ruby-lsp-0.26.1, erb_lint-0.9.0, web-console-4.2.1, capybara-3.40.0, selenium-webdriver-4.35.0, webmock-3.25.1, tailwindcss-rails-4.3.0, kaminari-1.2.2, rouge-4.6.0, redcarpet-3.6.1, metainspector-5.16.0, net-smtp-0.5.1, feedjira-4.0.1, faraday-http-cache-2.5.1, actioncable-8.0.2.1, actionmailbox-8.0.2.1, actionmailer-8.0.2.1, actionpack-8.0.2.1, actiontext-8.0.2.1, actionview-8.0.2.1, activejob-8.0.2.1, activemodel-8.0.2.1, activerecord-8.0.2.1, activestorage-8.0.2.1, activesupport-8.0.2.1, railties-8.0.2.1, rack-3.2.0, nio4r-2.7.4, concurrent-ruby-1.3.5, fugit-1.11.2, thor-1.4.0, msgpack-1.8.0, base64-0.3.0, bcrypt_pbkdf-1.1.1, dotenv-3.1.8, ed25519-1.4.0, net-ssh-7.3.0, sshkit-1.24.0, zeitwerk-2.7.3, mini_magick-5.2.0, ruby-vips-2.2.3, irb-1.15.2, reline-0.6.2, rubocop-1.73.1, rubocop-performance-1.24.0, rubocop-rails-2.30.2, language_server-protocol-3.17.0.4, prism-1.4.0, rbs-3.9.4, better_html-2.1.1, parser-3.3.7.1, rainbow-3.1.1, smart_properties-1.17.0, bindex-0.8.1, addressable-2.8.7, mini_mime-1.1.5, nokogiri-1.18.9-aarch64-linux-gnu, nokogiri-1.18.9, rack-test-2.2.0, regexp_parser-2.10.0, xpath-3.2.0, logger-1.7.0, rexml-3.4.1, rubyzip-3.0.2, websocket-1.2.11, crack-1.0.0, hashdiff-1.2.0, tailwindcss-ruby-4.1.12-aarch64-linux-gnu, tailwindcss-ruby-4.1.12, kaminari-actionview-1.2.2, kaminari-activerecord-1.2.2, kaminari-core-1.2.2, faraday-2.13.1, faraday-cookie_jar-0.0.7, faraday-encoding-0.0.6, faraday-follow_redirects-0.3.0, faraday-gzip-2.0.1, faraday-retry-2.3.1, fastimage-2.4.0, nesty-1.0.2, loofah-2.24.1, sax-machine-1.3.2, websocket-driver-0.8.0, mail-2.8.1, rails-dom-testing-2.3.0, rack-session-2.1.1, rails-html-sanitizer-1.6.2, useragent-0.16.11, globalid-1.2.1, builder-3.3.0, erubi-1.13.1, marcel-1.0.4, benchmark-0.4.1, bigdecimal-3.2.2, connection_pool-2.5.3, drb-2.2.3, i18n-1.14.7, minitest-5.25.5, tzinfo-2.0.6, uri-1.0.3, rackup-2.2.1, rake-13.3.0, et-orbi-1.3.0, raabro-1.4.0, net-scp-4.1.0, net-sftp-4.0.0, ostruct-0.6.3, ffi-1.17.1-aarch64-linux-gnu, ffi-1.17.1, rdoc-6.14.2, io-console-0.8.1, json-2.12.0, lint_roller-1.1.0, parallel-1.26.3, rubocop-ast-1.38.1, ruby-progressbar-1.13.0, unicode-display_width-3.1.4, ast-2.4.2, public_suffix-6.0.2, faraday-net_http-3.4.0, http-cookie-1.0.8, crass-1.0.6, websocket-extensions-0.1.5, net-imap-0.5.9, erb-5.0.2, psych-5.2.6, unicode-emoji-4.0.4, domain_name-0.6.20240107, stringio-3.1.7 in locally installed gems
Run `bundle install` to install missing gems.
```

---

**🧑‍🚒 Response (32)**: 
Let me install the required gems first:
**👀‍ Observation (32)**:
```
Don't run Bundler as root. Installing your bundle as root will break this
application for all non-root users on this machine.
Fetching gem metadata from https://rubygems.org/........
Fetching rake 13.3.0
Installing rake 13.3.0
Fetching base64 0.3.0
Fetching benchmark 0.4.1
Fetching bigdecimal 3.2.2
Fetching concurrent-ruby 1.3.5
Installing base64 0.3.0
Fetching connection_pool 2.5.3
Installing benchmark 0.4.1
Fetching drb 2.2.3
Installing bigdecimal 3.2.2 with native extensions
Installing concurrent-ruby 1.3.5
Fetching logger 1.7.0
Installing connection_pool 2.5.3
Fetching minitest 5.25.5
Installing drb 2.2.3
Fetching securerandom 0.4.1
Installing logger 1.7.0
Fetching uri 1.0.3
Installing minitest 5.25.5
Fetching builder 3.3.0
Installing securerandom 0.4.1
Fetching erubi 1.13.1
Installing uri 1.0.3
Fetching crass 1.0.6
Installing builder 3.3.0
Fetching rack 3.2.0
Installing erubi 1.13.1
Fetching useragent 0.16.11
Installing crass 1.0.6
Fetching nio4r 2.7.4
Installing rack 3.2.0
Fetching websocket-extensions 0.1.5
Installing useragent 0.16.11
Fetching zeitwerk 2.7.3
Installing nio4r 2.7.4 with native extensions
Installing websocket-extensions 0.1.5
Fetching timeout 0.4.3
Installing zeitwerk 2.7.3
Fetching marcel 1.0.4
Installing timeout 0.4.3
Fetching mini_mime 1.1.5
Installing marcel 1.0.4
Fetching date 3.4.1
Installing mini_mime 1.1.5
Fetching public_suffix 6.0.2
Installing date 3.4.1 with native extensions
Installing public_suffix 6.0.2
Fetching ast 2.4.2
Installing ast 2.4.2
Fetching bcrypt 3.1.20
Installing bcrypt 3.1.20 with native extensions
Fetching bcrypt_pbkdf 1.1.1
Installing bcrypt_pbkdf 1.1.1 with native extensions
Fetching smart_properties 1.17.0
Installing smart_properties 1.17.0
Fetching bindex 0.8.1
Installing bindex 0.8.1 with native extensions
Fetching msgpack 1.8.0
Installing msgpack 1.8.0 with native extensions
Fetching regexp_parser 2.10.0
Installing regexp_parser 2.10.0
Fetching rexml 3.4.1
Installing rexml 3.4.1
Fetching prettyprint 0.2.0
Installing prettyprint 0.2.0
Fetching erb 5.0.2
Installing erb 5.0.2 with native extensions
Fetching stringio 3.1.7
Installing stringio 3.1.7 with native extensions
Fetching io-console 0.8.1
Installing io-console 0.8.1 with native extensions
Fetching domain_name 0.6.20240107
Installing domain_name 0.6.20240107
Fetching dotenv 3.1.8
Installing dotenv 3.1.8
Fetching ed25519 1.4.0
Fetching rainbow 3.1.1
Installing ed25519 1.4.0 with native extensions
Installing rainbow 3.1.1
Fetching json 2.12.0
Installing json 2.12.0 with native extensions
Fetching language_server-protocol 3.17.0.4
Installing language_server-protocol 3.17.0.4
Fetching lint_roller 1.1.0
Installing lint_roller 1.1.0
Fetching parallel 1.26.3
Installing parallel 1.26.3
Fetching ruby-progressbar 1.13.0
Installing ruby-progressbar 1.13.0
Fetching unicode-emoji 4.0.4
Installing unicode-emoji 4.0.4
Fetching zlib 3.2.1
Installing zlib 3.2.1 with native extensions
Fetching fastimage 2.4.0
Installing fastimage 2.4.0
Fetching sax-machine 1.3.2
Installing sax-machine 1.3.2
Fetching ffi 1.17.1 (aarch64-linux-gnu)
Installing ffi 1.17.1 (aarch64-linux-gnu)
Fetching raabro 1.4.0
Installing raabro 1.4.0
Fetching hashdiff 1.2.0
Installing hashdiff 1.2.0
Fetching thor 1.4.0
Installing thor 1.4.0
Fetching net-ssh 7.3.0
Installing net-ssh 7.3.0
Fetching ostruct 0.6.3
Installing ostruct 0.6.3
Fetching kaminari-core 1.2.2
Installing kaminari-core 1.2.2
Fetching nesty 1.0.2
Installing nesty 1.0.2
Fetching prism 1.4.0
Installing prism 1.4.0 with native extensions
Fetching redcarpet 3.6.1
Installing redcarpet 3.6.1 with native extensions
Fetching rouge 4.6.0
Installing rouge 4.6.0
Fetching rubyzip 3.0.2
Installing rubyzip 3.0.2
Fetching websocket 1.2.11
Installing websocket 1.2.11
Fetching sqlite3 2.7.3 (aarch64-linux-gnu)
Installing sqlite3 2.7.3 (aarch64-linux-gnu)
Fetching tailwindcss-ruby 4.1.12 (aarch64-linux-gnu)
Fetching thruster 0.1.15 (aarch64-linux)
Fetching i18n 1.14.7
Installing i18n 1.14.7
Fetching tzinfo 2.0.6
Installing tzinfo 2.0.6
Fetching mini_magick 5.2.0
Installing mini_magick 5.2.0
Fetching rbs 3.9.4
Installing rbs 3.9.4 with native extensions
Installing thruster 0.1.15 (aarch64-linux)
Fetching net-http 0.6.0
Installing net-http 0.6.0
Fetching nokogiri 1.18.9 (aarch64-linux-gnu)
Installing tailwindcss-ruby 4.1.12 (aarch64-linux-gnu)
Installing nokogiri 1.18.9 (aarch64-linux-gnu)
Fetching brakeman 7.1.0
Installing brakeman 7.1.0
Fetching rack-session 2.1.1
Installing rack-session 2.1.1
Fetching rack-test 2.2.0
Installing rack-test 2.2.0
Fetching rackup 2.2.1
Installing rackup 2.2.1
Fetching websocket-driver 0.8.0
Fetching net-protocol 0.2.2
Installing websocket-driver 0.8.0 with native extensions
Fetching addressable 2.8.7
Installing net-protocol 0.2.2
Installing addressable 2.8.7
Fetching parser 3.3.7.1
Fetching puma 7.0.1
Fetching pp 0.6.2
Installing parser 3.3.7.1
Installing pp 0.6.2
Installing puma 7.0.1 with native extensions
Fetching psych 5.2.6
Installing psych 5.2.6 with native extensions
Fetching http-cookie 1.0.8
Installing http-cookie 1.0.8
Fetching crack 1.0.0
Installing crack 1.0.0
Fetching bootsnap 1.18.6
Installing bootsnap 1.18.6 with native extensions
Fetching unicode-display_width 3.1.4
Installing unicode-display_width 3.1.4
Fetching ruby-vips 2.2.3
Installing ruby-vips 2.2.3
Fetching net-scp 4.1.0
Installing net-scp 4.1.0
Fetching net-sftp 4.0.0
Fetching reline 0.6.2
Installing net-sftp 4.0.0
Fetching selenium-webdriver 4.35.0
Installing reline 0.6.2
Fetching activesupport 8.0.2.1
Installing activesupport 8.0.2.1
Fetching et-orbi 1.3.0
Installing et-orbi 1.3.0
Fetching faraday-net_http 3.4.0
Installing faraday-net_http 3.4.0
Fetching loofah 2.24.1
Installing loofah 2.24.1
Fetching xpath 3.2.0
Installing selenium-webdriver 4.35.0
Installing xpath 3.2.0
Fetching net-imap 0.5.9
Installing net-imap 0.5.9
Fetching net-smtp 0.5.1
Installing net-smtp 0.5.1
Fetching rubocop-ast 1.38.1
Fetching webmock 3.25.1
Installing rubocop-ast 1.38.1
Fetching image_processing 1.14.0
Installing webmock 3.25.1
Installing image_processing 1.14.0
Fetching rdoc 6.14.2
Fetching sshkit 1.24.0
Fetching rails-dom-testing 2.3.0
Installing rdoc 6.14.2
Installing sshkit 1.24.0
Installing rails-dom-testing 2.3.0
Fetching globalid 1.2.1
Installing globalid 1.2.1
Fetching activemodel 8.0.2.1
Fetching fugit 1.11.2
Fetching faraday 2.13.1
Installing activemodel 8.0.2.1
Fetching rails-html-sanitizer 1.6.2
Installing fugit 1.11.2
Fetching feedjira 4.0.1
Installing faraday 2.13.1
Fetching capybara 3.40.0
Installing rails-html-sanitizer 1.6.2
Fetching mail 2.8.1
Installing feedjira 4.0.1
Fetching rubocop 1.73.1
Installing capybara 3.40.0
Installing mail 2.8.1
Installing rubocop 1.73.1
Fetching activejob 8.0.2.1
Installing activejob 8.0.2.1
Fetching kamal 2.7.0
Installing kamal 2.7.0
Fetching irb 1.15.2
Installing irb 1.15.2
Fetching activerecord 8.0.2.1
Fetching faraday-cookie_jar 0.0.7
Fetching faraday-encoding 0.0.6
Installing activerecord 8.0.2.1
Installing faraday-cookie_jar 0.0.7
Fetching faraday-follow_redirects 0.3.0
Installing faraday-encoding 0.0.6
Fetching faraday-gzip 2.0.1
Installing faraday-follow_redirects 0.3.0
Fetching faraday-http-cache 2.5.1
Installing faraday-gzip 2.0.1
Fetching faraday-retry 2.3.1
Installing faraday-http-cache 2.5.1
Fetching actionview 8.0.2.1
Fetching debug 1.11.0
Installing faraday-retry 2.3.1
Fetching rubocop-performance 1.24.0
Installing actionview 8.0.2.1
Fetching rubocop-rails 2.30.2
Installing debug 1.11.0 with native extensions
Installing rubocop-performance 1.24.0
Fetching kaminari-activerecord 1.2.2
Installing rubocop-rails 2.30.2
Installing kaminari-activerecord 1.2.2
Fetching metainspector 5.16.0
Fetching actionpack 8.0.2.1
Installing metainspector 5.16.0
Fetching better_html 2.1.1
Installing actionpack 8.0.2.1
Fetching jbuilder 2.14.1
Installing better_html 2.1.1 with native extensions
Fetching kaminari-actionview 1.2.2
Installing jbuilder 2.14.1
Fetching rubocop-rails-omakase 1.1.0
Installing kaminari-actionview 1.2.2
Fetching actioncable 8.0.2.1
Installing rubocop-rails-omakase 1.1.0
Fetching activestorage 8.0.2.1
Installing actioncable 8.0.2.1
Fetching actionmailer 8.0.2.1
Installing activestorage 8.0.2.1
Fetching railties 8.0.2.1
Installing actionmailer 8.0.2.1
Fetching propshaft 1.2.1
Installing railties 8.0.2.1
Installing propshaft 1.2.1
Fetching kaminari 1.2.2
Fetching actionmailbox 8.0.2.1
Fetching actiontext 8.0.2.1
Installing kaminari 1.2.2
Fetching erb_lint 0.9.0
Installing actionmailbox 8.0.2.1
Fetching importmap-rails 2.2.2
Installing actiontext 8.0.2.1
Fetching solid_cable 3.0.12
Installing erb_lint 0.9.0
Fetching solid_cache 1.0.7
Installing importmap-rails 2.2.2
Fetching solid_queue 1.2.1
Installing solid_cable 3.0.12
Fetching stimulus-rails 1.3.4
Installing solid_cache 1.0.7
Fetching tailwindcss-rails 4.3.0
Installing solid_queue 1.2.1
Fetching turbo-rails 2.0.16
Installing stimulus-rails 1.3.4
Fetching web-console 4.2.1
Installing tailwindcss-rails 4.3.0
Fetching rails 8.0.2.1
Installing turbo-rails 2.0.16
Installing web-console 4.2.1
Installing rails 8.0.2.1
Fetching ruby-lsp 0.26.1
Installing ruby-lsp 0.26.1
Bundle complete! 34 Gemfile dependencies, 157 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
Post-install message from solid_cache:
Upgrading from Solid Cache v0.3 or earlier? There are new database migrations in v0.4.
See https://github.com/rails/solid_cache/blob/main/upgrading_to_version_0.4.x.md for upgrade instructions.
Post-install message from solid_queue:
Upgrading from Solid Queue < 1.0? Check details on breaking changes and upgrade instructions
--> https://github.com/rails/solid_queue/blob/main/UPGRADING.md
Post-install message from tailwindcss-rails:
== Upgrading to Tailwind CSS v4 ==

If you are upgrading to tailwindcss-rails 4.x, please read the upgrade guide at:

  https://github.com/rails/tailwindcss-rails/blob/main/README.md#upgrading-your-application-from-tailwind-v3-to-v4

If you're not ready to upgrade yet, please pin to version 3 in your Gemfile:

  gem "tailwindcss-rails", "~> 3.3.1"

1 installed gem you directly depend on is looking for funding.
  Run `bundle fund` for details
```

---

**🧑‍🚒 Response (33)**: 
Now let's try running the tests:
**👀‍ Observation (33)**:
```
Running 5 tests in a single process (parallelization threshold is 50)
Run options: --seed 63779

# Running:

.E

Error:
LinksControllerTest#test_feed_should_use_proper_URLs_for_arXiv_papers:
WebMock::NetConnectNotAllowedError: Real HTTP connections are disabled. Unregistered request: GET http://example.com/link with headers {'Accept'=>'*/*', 'Accept-Encoding'=>'identity', 'User-Agent'=>'MetaInspector/5.16.0 (+https://github.com/jaimeiniesta/metainspector)'}

You can stub this request with the following snippet:

stub_request(:get, "http://example.com/link").
  with(
    headers: {
	  'Accept'=>'*/*',
	  'Accept-Encoding'=>'identity',
	  'User-Agent'=>'MetaInspector/5.16.0 (+https://github.com/jaimeiniesta/metainspector)'
    }).
  to_return(status: 200, body: "", headers: {})

============================================================
    app/models/link.rb:16:in 'Link#set_title_and_desc'
    test/controllers/links_controller_test.rb:64:in 'block in <class:LinksControllerTest>'


bin/rails test test/controllers/links_controller_test.rb:62

E

Error:
LinksControllerTest#test_feed_should_be_ordered_by_creation_date:
WebMock::NetConnectNotAllowedError: Real HTTP connections are disabled. Unregistered request: GET http://example.com/oldest with headers {'Accept'=>'*/*', 'Accept-Encoding'=>'identity', 'User-Agent'=>'MetaInspector/5.16.0 (+https://github.com/jaimeiniesta/metainspector)'}

You can stub this request with the following snippet:

stub_request(:get, "http://example.com/oldest").
  with(
    headers: {
	  'Accept'=>'*/*',
	  'Accept-Encoding'=>'identity',
	  'User-Agent'=>'MetaInspector/5.16.0 (+https://github.com/jaimeiniesta/metainspector)'
    }).
  to_return(status: 200, body: "", headers: {})

============================================================
    app/models/link.rb:16:in 'Link#set_title_and_desc'
    test/controllers/links_controller_test.rb:85:in 'block in <class:LinksControllerTest>'


bin/rails test test/controllers/links_controller_test.rb:83

/usr/local/lib/ruby/gems/3.4.0/gems/marcel-1.0.4/lib/marcel/magic.rb:120: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
.E

Error:
LinksControllerTest#test_feed_should_include_both_links_and_papers:
WebMock::NetConnectNotAllowedError: Real HTTP connections are disabled. Unregistered request: GET http://example.com/link1 with headers {'Accept'=>'*/*', 'Accept-Encoding'=>'identity', 'User-Agent'=>'MetaInspector/5.16.0 (+https://github.com/jaimeiniesta/metainspector)'}

You can stub this request with the following snippet:

stub_request(:get, "http://example.com/link1").
  with(
    headers: {
	  'Accept'=>'*/*',
	  'Accept-Encoding'=>'identity',
	  'User-Agent'=>'MetaInspector/5.16.0 (+https://github.com/jaimeiniesta/metainspector)'
    }).
  to_return(status: 200, body: "", headers: {})

============================================================
    app/models/link.rb:16:in 'Link#set_title_and_desc'
    test/controllers/links_controller_test.rb:38:in 'block in <class:LinksControllerTest>'


bin/rails test test/controllers/links_controller_test.rb:36



Finished in 2.023142s, 2.4714 runs/s, 3.9542 assertions/s.
5 runs, 8 assertions, 0 failures, 3 errors, 0 skips
```

---

**🧑‍🚒 Response (34)**: 
I see the issue. The Link model's `before_create` callback is trying to fetch metadata from the URLs, but WebMock is preventing these HTTP requests. I need to stub these requests in my tests. Let me update the test file:
**👀‍ Observation (34)**:
```

```

... (truncated due to length limit)
</details>