### PR TITLE
Add mise.toml for polyglot toolchain management

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,3 @@
+[tools]
+ruby = "3.4.1"
+bun = "latest"


### PR DESCRIPTION
Adds a `mise.toml` at the project root for easier dev environment setup.

This allows new contributors to run:

```bash
git clone <repo>
cd abbey
mise trust
mise install
```

And get the correct toolchain without needing to manually install Ruby or Bun.

## Tools pinned

- **ruby**: `3.4.1` (matches existing `.ruby-version`)
- **bun**: `latest` (for Tailwind CSS compilation)
