### PR TITLE
Remove stale importmap pin for nonexistent app/javascript/uploading.js

### DIFF
--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -6,4 +6,3 @@ pin "@hotwired/stimulus", to: "stimulus.min.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
 pin_all_from "app/javascript/controllers", under: "controllers"
 pin "@rails/activestorage", to: "@rails--activestorage.js" # @8.0.100
-pin "app/javascript/uploading"


### PR DESCRIPTION
## Summary

`config/importmap.rb` pins `"app/javascript/uploading"`, but the file `app/javascript/uploading.js` has never existed in this repository (the pin was added in the initial commit and has been an orphan ever since). The result is a noisy warning on every page render that loads the importmap, e.g. on the post / page edit forms:

```
Importmap skipped missing path: app/javascript/uploading.js
Importmap skipped missing path: app/javascript/uploading.js
Importmap skipped missing path: app/javascript/uploading.js
```

The Stimulus controller that actually powers `data-controller="uploading"` on the markdown_excerpt / markdown_body textareas lives at `app/javascript/controllers/uploading_controller.js` and is auto-registered through the existing infrastructure:

```ruby
# config/importmap.rb
pin_all_from "app/javascript/controllers", under: "controllers"
```

```js
// app/javascript/controllers/index.js
import { eagerLoadControllersFrom } from "@hotwired/stimulus-loading"
eagerLoadControllersFrom("controllers", application)
```

So the stray pin is dead weight — removing it silences the warning and changes nothing about upload behavior.

## Why this is safe

- `git log --diff-filter=A --name-only -- app/javascript/uploading.js` returns nothing on `main` — the file has never existed.
- The actual Stimulus controller at `app/javascript/controllers/uploading_controller.js` is unaffected and continues to register as `uploading` via Stimulus' auto-loader.
- Active Storage's `@rails/activestorage` is still pinned (the line right above).

## Test plan

- [x] On a working tree, render `/blog/new` and `/p/about` after the change — no `Importmap skipped` lines in `log/development.log`.
- [x] Markdown editor textareas (`form.textarea ..., data: { controller: "uploading" }`) still attach the Stimulus controller — drag-and-drop / paste-upload behavior unchanged.
- [x] Production blog (https://enriquecanals.com) running this exact change continues to handle uploads correctly.

Made with [Cursor](https://cursor.com)